### PR TITLE
Fix `RunFilterParameter` doesn't use the default value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>${workflow.version}</version>
             <optional>true</optional>

--- a/src/main/java/org/jenkinsci/plugins/runselector/filters/RunFilterParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/runselector/filters/RunFilterParameter.java
@@ -70,6 +70,14 @@ public class RunFilterParameter extends SimpleParameterDefinition {
      * {@inheritDoc}
      */
     @Override
+    public ParameterValue getDefaultParameterValue() {
+        return createValue(ParameterizedRunFilter.encodeToXml(getDefaultFilter()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public ParameterValue createValue(String value) {
         return new StringParameterValue(getName(), value, getDescription());
     }

--- a/src/test/java/org/jenkinsci/plugins/runselector/filters/ParameterizedRunFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/filters/ParameterizedRunFilterTest.java
@@ -24,8 +24,6 @@
 
 package org.jenkinsci.plugins.runselector.filters;
 
-import java.util.Arrays;
-
 import org.apache.commons.lang.RandomStringUtils;
 import org.jenkinsci.plugins.runselector.steps.RunSelectorStep;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -39,7 +37,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import hudson.model.Item;
-import hudson.model.ParameterDefinition;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
@@ -53,20 +50,20 @@ public class ParameterizedRunFilterTest {
     @ClassRule
     public static final JenkinsRule j = new JenkinsRule();
 
-    private static WorkflowJob jobToCopyFrom;
-    private static WorkflowRun runToCopyFrom1;
-    private static WorkflowRun runToCopyFrom2;
+    private static WorkflowJob jobToSelect;
+    private static WorkflowRun runToSelect1;
+    private static WorkflowRun runToSelect2;
 
     @BeforeClass
-    public static void prepareBuildsToCopyFrom() throws Exception {
-        jobToCopyFrom = j.jenkins.createProject(
+    public static void prepareBuildsToSelect() throws Exception {
+        jobToSelect = j.jenkins.createProject(
             WorkflowJob.class,
             RandomStringUtils.randomAlphanumeric(7)
         );
-        jobToCopyFrom.setDefinition(new CpsFlowDefinition("// do nothing"));
-        runToCopyFrom1 = j.assertBuildStatusSuccess(jobToCopyFrom.scheduleBuild2(0));
-        runToCopyFrom2 = j.assertBuildStatusSuccess(jobToCopyFrom.scheduleBuild2(0));
-        runToCopyFrom1.keepLog();
+        jobToSelect.setDefinition(new CpsFlowDefinition("// do nothing"));
+        runToSelect1 = j.assertBuildStatusSuccess(jobToSelect.scheduleBuild2(0));
+        runToSelect2 = j.assertBuildStatusSuccess(jobToSelect.scheduleBuild2(0));
+        runToSelect1.keepLog();
     }
 
     @Test
@@ -83,9 +80,7 @@ public class ParameterizedRunFilterTest {
                 WorkflowJob.class,
                 RandomStringUtils.randomAlphanumeric(7)
         );
-        job.addProperty(new ParametersDefinitionProperty(
-            Arrays.<ParameterDefinition>asList(param)
-        ));
+        job.addProperty(new ParametersDefinitionProperty(param));
         j.configRoundtrip((Item)job);
         j.assertEqualDataBoundBeans(
             param,
@@ -110,11 +105,11 @@ public class ParameterizedRunFilterTest {
             RandomStringUtils.randomAlphanumeric(7)
         );
         selecter.addProperty(new ParametersDefinitionProperty(
-            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+            new RunFilterParameter(
                 "FILTER",
                 "description",
                 new SavedRunFilter()
-            ))
+            )
         ));
         selecter.setDefinition(new CpsFlowDefinition(String.format(
             "def runWrapper = runSelector"
@@ -122,8 +117,8 @@ public class ParameterizedRunFilterTest {
             + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
             + " verbose: true;"
             + "assert(runWrapper.id == '%s')",
-            jobToCopyFrom.getFullName(),
-            runToCopyFrom1.getId()
+            jobToSelect.getFullName(),
+            runToSelect1.getId()
         )));
 
         j.assertBuildStatusSuccess(selecter.scheduleBuild2(0));
@@ -136,11 +131,11 @@ public class ParameterizedRunFilterTest {
             RandomStringUtils.randomAlphanumeric(7)
         );
         selecter.addProperty(new ParametersDefinitionProperty(
-            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+            new RunFilterParameter(
                 "FILTER",
                 "description",
                 new NoRunFilter()
-            ))
+            )
         ));
         selecter.setDefinition(new CpsFlowDefinition(String.format(
             "def runWrapper = runSelector"
@@ -148,8 +143,8 @@ public class ParameterizedRunFilterTest {
             + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
             + " verbose: true;"
             + "assert(runWrapper.id == '%s')",
-            jobToCopyFrom.getFullName(),
-            runToCopyFrom1.getId()
+            jobToSelect.getFullName(),
+            runToSelect1.getId()
         )));
 
         j.assertBuildStatusSuccess(selecter.scheduleBuild2(
@@ -167,11 +162,11 @@ public class ParameterizedRunFilterTest {
             RandomStringUtils.randomAlphanumeric(7)
         );
         selecter.addProperty(new ParametersDefinitionProperty(
-            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+            new RunFilterParameter(
                 "FILTER",
                 "description",
                 new SavedRunFilter()
-            ))
+            )
         ));
         selecter.setDefinition(new CpsFlowDefinition(String.format(
             "def runWrapper = runSelector"
@@ -179,8 +174,8 @@ public class ParameterizedRunFilterTest {
             + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
             + " verbose: true;"
             + "assert(runWrapper.id == '%s')",
-            jobToCopyFrom.getFullName(),
-            runToCopyFrom1.getId()
+            jobToSelect.getFullName(),
+            runToSelect1.getId()
         )));
 
         WebClient wc = j.createWebClient();
@@ -199,18 +194,18 @@ public class ParameterizedRunFilterTest {
             RandomStringUtils.randomAlphanumeric(7)
         );
         selecter.addProperty(new ParametersDefinitionProperty(
-            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+            new RunFilterParameter(
                 "FILTER",
                 "description",
                 new NoRunFilter()
-            ))
+            )
         ));
         selecter.setDefinition(new CpsFlowDefinition(String.format(
             "def runWrapper = runSelector"
             + " job: '%s',"
             + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
             + " verbose: true;",
-            jobToCopyFrom.getFullName()
+            jobToSelect.getFullName()
         )));
 
         j.assertBuildStatus(
@@ -231,11 +226,11 @@ public class ParameterizedRunFilterTest {
             RandomStringUtils.randomAlphanumeric(7)
         );
         selecter.addProperty(new ParametersDefinitionProperty(
-            Arrays.<ParameterDefinition>asList(new StringParameterDefinition(
+            new StringParameterDefinition(
                 "FILTER",
                 "",
                 "description"
-            ))
+            )
         ));
         selecter.setDefinition(new CpsFlowDefinition(String.format(
             "def runWrapper = runSelector"
@@ -243,8 +238,8 @@ public class ParameterizedRunFilterTest {
             + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
             + " verbose: true;"
             + "assert(runWrapper.id == '%s')",
-            jobToCopyFrom.getFullName(),
-            runToCopyFrom2.getId()
+            jobToSelect.getFullName(),
+            runToSelect2.getId()
         )));
 
         j.assertBuildStatusSuccess(selecter.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/runselector/filters/ParameterizedRunFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/filters/ParameterizedRunFilterTest.java
@@ -1,0 +1,252 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.runselector.filters;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.jenkinsci.plugins.runselector.steps.RunSelectorStep;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import hudson.model.Item;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+
+/**
+ * Tests for {@link RunFilterParameter} and {@link ParameterizedRunFilter}
+ */
+public class ParameterizedRunFilterTest {
+    @ClassRule
+    public static final JenkinsRule j = new JenkinsRule();
+
+    private static WorkflowJob jobToCopyFrom;
+    private static WorkflowRun runToCopyFrom1;
+    private static WorkflowRun runToCopyFrom2;
+
+    @BeforeClass
+    public static void prepareBuildsToCopyFrom() throws Exception {
+        jobToCopyFrom = j.jenkins.createProject(
+            WorkflowJob.class,
+            RandomStringUtils.randomAlphanumeric(7)
+        );
+        jobToCopyFrom.setDefinition(new CpsFlowDefinition("// do nothing"));
+        runToCopyFrom1 = j.assertBuildStatusSuccess(jobToCopyFrom.scheduleBuild2(0));
+        runToCopyFrom2 = j.assertBuildStatusSuccess(jobToCopyFrom.scheduleBuild2(0));
+        runToCopyFrom1.keepLog();
+    }
+
+    @Test
+    public void testConfigureBuildFilterParameter() throws Exception {
+        RunFilterParameter param = new RunFilterParameter(
+            "PARAM",
+            "description",
+            new AndRunFilter(
+                new ParametersRunFilter("PARAM1=VALUE1"),
+                new SavedRunFilter()
+            )
+        );
+        WorkflowJob job = j.jenkins.createProject(
+                WorkflowJob.class,
+                RandomStringUtils.randomAlphanumeric(7)
+        );
+        job.addProperty(new ParametersDefinitionProperty(
+            Arrays.<ParameterDefinition>asList(param)
+        ));
+        j.configRoundtrip((Item)job);
+        j.assertEqualDataBoundBeans(
+            param,
+            job.getProperty(ParametersDefinitionProperty.class)
+                .getParameterDefinition("PARAM")
+        );
+    }
+
+    @Test
+    public void testConfigureParameterizedBuildFilter() throws Exception {
+        ParameterizedRunFilter filter = new ParameterizedRunFilter("${PARAM}");
+        RunSelectorStep step = new RunSelectorStep("test");
+        step.setFilter(filter);
+        new StepConfigTester(j).configRoundTrip(step);
+        j.assertEqualDataBoundBeans(filter, step.getFilter());
+    }
+
+    @Test
+    public void testIsSelectableWithDefault() throws Exception {
+        WorkflowJob selecter = j.jenkins.createProject(
+            WorkflowJob.class,
+            RandomStringUtils.randomAlphanumeric(7)
+        );
+        selecter.addProperty(new ParametersDefinitionProperty(
+            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+                "FILTER",
+                "description",
+                new SavedRunFilter()
+            ))
+        ));
+        selecter.setDefinition(new CpsFlowDefinition(String.format(
+            "def runWrapper = runSelector"
+            + " job: '%s',"
+            + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
+            + " verbose: true;"
+            + "assert(runWrapper.id == '%s')",
+            jobToCopyFrom.getFullName(),
+            runToCopyFrom1.getId()
+        )));
+
+        j.assertBuildStatusSuccess(selecter.scheduleBuild2(0));
+    }
+
+    @Test
+    public void testIsSelectableWithParameter() throws Exception {
+        WorkflowJob selecter = j.jenkins.createProject(
+            WorkflowJob.class,
+            RandomStringUtils.randomAlphanumeric(7)
+        );
+        selecter.addProperty(new ParametersDefinitionProperty(
+            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+                "FILTER",
+                "description",
+                new NoRunFilter()
+            ))
+        ));
+        selecter.setDefinition(new CpsFlowDefinition(String.format(
+            "def runWrapper = runSelector"
+            + " job: '%s',"
+            + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
+            + " verbose: true;"
+            + "assert(runWrapper.id == '%s')",
+            jobToCopyFrom.getFullName(),
+            runToCopyFrom1.getId()
+        )));
+
+        j.assertBuildStatusSuccess(selecter.scheduleBuild2(
+            0,
+            new ParametersAction(
+                new StringParameterValue("FILTER", "<SavedRunFilter />")
+            )
+        ));
+    }
+
+    @Test
+    public void testIsSelectableWithUI() throws Exception {
+        WorkflowJob selecter = j.jenkins.createProject(
+            WorkflowJob.class,
+            RandomStringUtils.randomAlphanumeric(7)
+        );
+        selecter.addProperty(new ParametersDefinitionProperty(
+            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+                "FILTER",
+                "description",
+                new SavedRunFilter()
+            ))
+        ));
+        selecter.setDefinition(new CpsFlowDefinition(String.format(
+            "def runWrapper = runSelector"
+            + " job: '%s',"
+            + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
+            + " verbose: true;"
+            + "assert(runWrapper.id == '%s')",
+            jobToCopyFrom.getFullName(),
+            runToCopyFrom1.getId()
+        )));
+
+        WebClient wc = j.createWebClient();
+        // Jenkins sends 405 response for GET of build page.. deal with that:
+        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        wc.getOptions().setPrintContentOnFailingStatusCode(false);
+        j.submit(wc.getPage(selecter, "build").getFormByName("parameters"));
+        j.waitUntilNoActivity();
+        j.assertBuildStatusSuccess(selecter.getLastBuild());
+    }
+
+    @Test
+    public void testIsSelectableBadParameter() throws Exception {
+        WorkflowJob selecter = j.jenkins.createProject(
+            WorkflowJob.class,
+            RandomStringUtils.randomAlphanumeric(7)
+        );
+        selecter.addProperty(new ParametersDefinitionProperty(
+            Arrays.<ParameterDefinition>asList(new RunFilterParameter(
+                "FILTER",
+                "description",
+                new NoRunFilter()
+            ))
+        ));
+        selecter.setDefinition(new CpsFlowDefinition(String.format(
+            "def runWrapper = runSelector"
+            + " job: '%s',"
+            + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
+            + " verbose: true;",
+            jobToCopyFrom.getFullName()
+        )));
+
+        j.assertBuildStatus(
+            Result.FAILURE,
+            selecter.scheduleBuild2(
+                0,
+                new ParametersAction(
+                    new StringParameterValue("FILTER", "Bad Parameter")
+                )
+            ).get()
+        );
+    }
+
+    @Test
+    public void testIsSelectableEmptyParameter() throws Exception {
+        WorkflowJob selecter = j.jenkins.createProject(
+            WorkflowJob.class,
+            RandomStringUtils.randomAlphanumeric(7)
+        );
+        selecter.addProperty(new ParametersDefinitionProperty(
+            Arrays.<ParameterDefinition>asList(new StringParameterDefinition(
+                "FILTER",
+                "",
+                "description"
+            ))
+        ));
+        selecter.setDefinition(new CpsFlowDefinition(String.format(
+            "def runWrapper = runSelector"
+            + " job: '%s',"
+            + " filter: [$class: 'ParameterizedRunFilter', parameter: '${FILTER}'],"
+            + " verbose: true;"
+            + "assert(runWrapper.id == '%s')",
+            jobToCopyFrom.getFullName(),
+            runToCopyFrom2.getId()
+        )));
+
+        j.assertBuildStatusSuccess(selecter.scheduleBuild2(0));
+    }
+}


### PR DESCRIPTION
Add tests for `RunFilterParameter` and `ParameterizedRunFilter`, and it discovered a bug in `RunFilterParameter`.
I forgot to override `SimpleParameterDefinition#getDefaultParameterValue` and it caused default values of `RunFilterParameter` not used at all.
