### PR TITLE
Use uppercase names for build status 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ def runWrapper = selectRun 'upstream-project-name'
 
 Alternatively, you can specify the `StatusRunSelector`. 
 For example, if you'd like to select the last successful build (stable or unstable), the value of the 
-`buildStatus` parameter has to be *Successful*:
+`buildStatus` parameter has to be *SUCCESSFUL*:
  
 ```groovy
 def runWrapper = selectRun job: 'upstream-project-name', 
- selector: [$class: 'StatusRunSelector', buildStatus: 'Successful'] 
+ selector: [$class: 'StatusRunSelector', buildStatus: 'SUCCESSFUL']
 ```
 The complete list of `buildStatus` values may be found in the Pipeline *Snippet Generator*.
 

--- a/src/main/java/org/jenkinsci/plugins/runselector/selectors/StatusRunSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/runselector/selectors/StatusRunSelector.java
@@ -38,27 +38,40 @@ import javax.annotation.Nonnull;
 
 /**
  * Select build based on the specific status build.
+ *
  * @author Alan Harder
  */
 public class StatusRunSelector extends RunSelector {
     public enum BuildStatus {
-        /** Stable builds.*/
-        stable(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Stable()),
+        /**
+         * Stable builds.
+         */
+        STABLE(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Stable()),
 
-        /** Stable or Unstable builds.*/
-        successful(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Successful()),
+        /**
+         * Stable or Unstable builds.
+         */
+        SUCCESSFUL(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Successful()),
 
-        /** Unstable builds. */
-        unstable(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Unstable()),
+        /**
+         * Unstable builds.
+         */
+        UNSTABLE(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Unstable()),
 
-        /** Failed builds. */
-        failed(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Failed()),
+        /**
+         * Failed builds.
+         */
+        FAILED(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Failed()),
 
-        /** Completed builds with any build results.*/
-        completed(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Completed()),
+        /**
+         * Completed builds with any build results.
+         */
+        COMPLETED(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Completed()),
 
-        /** Any builds including incomplete (running) ones.*/
-        any(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Any());
+        /**
+         * Any builds including incomplete (running) ones.
+         */
+        ANY(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Any());
 
         private final Localizable displayName;
 
@@ -75,7 +88,7 @@ public class StatusRunSelector extends RunSelector {
     private final BuildStatus buildStatus;
 
     public StatusRunSelector() {
-        this(BuildStatus.stable);
+        this(BuildStatus.STABLE);
     }
 
     /**
@@ -83,7 +96,7 @@ public class StatusRunSelector extends RunSelector {
      */
     @DataBoundConstructor
     public StatusRunSelector(@CheckForNull BuildStatus buildStatus) {
-        this.buildStatus = buildStatus != null ? buildStatus : BuildStatus.stable;
+        this.buildStatus = buildStatus != null ? buildStatus : BuildStatus.STABLE;
     }
 
     /**
@@ -103,59 +116,59 @@ public class StatusRunSelector extends RunSelector {
         Run<?, ?> previousBuild = context.getLastMatchBuild();
         if (previousBuild == null) {
             // the first time
-            switch(getBuildStatus()) {
-                case stable:
-                return job.getLastStableBuild();
-                case unstable:
-                return job.getLastUnstableBuild();
-                case failed:
-                return job.getLastFailedBuild();
-                case successful:
-                // really confusing, but in this case,
-                // "successful" means marked as SUCCESS or UNSTABLE.
-                return job.getLastSuccessfulBuild();
-                case completed:
-                return job.getLastCompletedBuild();
-                case any:
-                return job.getLastBuild();
+            switch (getBuildStatus()) {
+                case STABLE:
+                    return job.getLastStableBuild();
+                case UNSTABLE:
+                    return job.getLastUnstableBuild();
+                case FAILED:
+                    return job.getLastFailedBuild();
+                case SUCCESSFUL:
+                    // really confusing, but in this case,
+                    // "successful" means marked as SUCCESS or UNSTABLE.
+                    return job.getLastSuccessfulBuild();
+                case COMPLETED:
+                    return job.getLastCompletedBuild();
+                case ANY:
+                    return job.getLastBuild();
             }
         } else {
             // the second or later time
-            switch(getBuildStatus()) {
-                case stable:
-                // really confusing, but in this case,
-                // "successful" means marked as SUCCESS.
-                return previousBuild.getPreviousSuccessfulBuild();
-                case unstable:
-                for (
-                        previousBuild = previousBuild.getPreviousBuild();
-                        previousBuild != null;
-                        previousBuild = previousBuild.getPreviousBuild()
-                ) {
-                    Result r = previousBuild.getResult();
-                    if (Result.UNSTABLE.equals(r)) {
-                        return previousBuild;
+            switch (getBuildStatus()) {
+                case STABLE:
+                    // really confusing, but in this case,
+                    // "successful" means marked as SUCCESS.
+                    return previousBuild.getPreviousSuccessfulBuild();
+                case UNSTABLE:
+                    for (
+                            previousBuild = previousBuild.getPreviousBuild();
+                            previousBuild != null;
+                            previousBuild = previousBuild.getPreviousBuild()
+                            ) {
+                        Result r = previousBuild.getResult();
+                        if (Result.UNSTABLE.equals(r)) {
+                            return previousBuild;
+                        }
                     }
-                }
-                break;
-                case failed:
-                return previousBuild.getPreviousFailedBuild();
-                case successful:
-                for (
-                        previousBuild = previousBuild.getPreviousBuild();
-                        previousBuild != null;
-                        previousBuild = previousBuild.getPreviousBuild()
-                ) {
-                    Result r = previousBuild.getResult();
-                    if (r != null && r.isBetterOrEqualTo(Result.UNSTABLE)) {
-                        return previousBuild;
+                    break;
+                case FAILED:
+                    return previousBuild.getPreviousFailedBuild();
+                case SUCCESSFUL:
+                    for (
+                            previousBuild = previousBuild.getPreviousBuild();
+                            previousBuild != null;
+                            previousBuild = previousBuild.getPreviousBuild()
+                            ) {
+                        Result r = previousBuild.getResult();
+                        if (r != null && r.isBetterOrEqualTo(Result.UNSTABLE)) {
+                            return previousBuild;
+                        }
                     }
-                }
-                break;
-                case completed:
-                return previousBuild.getPreviousCompletedBuild();
-                case any:
-                return previousBuild.getPreviousBuild();
+                    break;
+                case COMPLETED:
+                    return previousBuild.getPreviousCompletedBuild();
+                case ANY:
+                    return previousBuild.getPreviousBuild();
             }
         }
         return null;
@@ -173,8 +186,8 @@ public class StatusRunSelector extends RunSelector {
         );
     }
 
-    @Extension(ordinal=100)
+    @Extension(ordinal = 100)
     public static final Descriptor<RunSelector> DESCRIPTOR =
             new SimpleRunSelectorDescriptor(
-                StatusRunSelector.class, org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_DisplayName());
+                    StatusRunSelector.class, org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_DisplayName());
 }

--- a/src/main/java/org/jenkinsci/plugins/runselector/selectors/StatusRunSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/runselector/selectors/StatusRunSelector.java
@@ -43,22 +43,22 @@ import javax.annotation.Nonnull;
 public class StatusRunSelector extends RunSelector {
     public enum BuildStatus {
         /** Stable builds.*/
-        Stable(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Stable()),
+        stable(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Stable()),
 
         /** Stable or Unstable builds.*/
-        Successful(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Successful()),
+        successful(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Successful()),
 
         /** Unstable builds. */
-        Unstable(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Unstable()),
+        unstable(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Unstable()),
 
         /** Failed builds. */
-        Failed(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Failed()),
+        failed(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Failed()),
 
         /** Completed builds with any build results.*/
-        Completed(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Completed()),
+        completed(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Completed()),
 
         /** Any builds including incomplete (running) ones.*/
-        Any(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Any());
+        any(org.jenkinsci.plugins.runselector.Messages._StatusRunSelector_BuildStatus_Any());
 
         private final Localizable displayName;
 
@@ -75,7 +75,7 @@ public class StatusRunSelector extends RunSelector {
     private final BuildStatus buildStatus;
 
     public StatusRunSelector() {
-        this(BuildStatus.Stable);
+        this(BuildStatus.stable);
     }
 
     /**
@@ -83,7 +83,7 @@ public class StatusRunSelector extends RunSelector {
      */
     @DataBoundConstructor
     public StatusRunSelector(@CheckForNull BuildStatus buildStatus) {
-        this.buildStatus = buildStatus != null ? buildStatus : BuildStatus.Stable;
+        this.buildStatus = buildStatus != null ? buildStatus : BuildStatus.stable;
     }
 
     /**
@@ -104,29 +104,29 @@ public class StatusRunSelector extends RunSelector {
         if (previousBuild == null) {
             // the first time
             switch(getBuildStatus()) {
-            case Stable:
+                case stable:
                 return job.getLastStableBuild();
-            case Unstable:
+                case unstable:
                 return job.getLastUnstableBuild();
-            case Failed:
+                case failed:
                 return job.getLastFailedBuild();
-            case Successful:
+                case successful:
                 // really confusing, but in this case,
                 // "successful" means marked as SUCCESS or UNSTABLE.
                 return job.getLastSuccessfulBuild();
-            case Completed:
+                case completed:
                 return job.getLastCompletedBuild();
-            case Any:
+                case any:
                 return job.getLastBuild();
             }
         } else {
             // the second or later time
             switch(getBuildStatus()) {
-            case Stable:
+                case stable:
                 // really confusing, but in this case,
                 // "successful" means marked as SUCCESS.
                 return previousBuild.getPreviousSuccessfulBuild();
-            case Unstable:
+                case unstable:
                 for (
                         previousBuild = previousBuild.getPreviousBuild();
                         previousBuild != null;
@@ -138,9 +138,9 @@ public class StatusRunSelector extends RunSelector {
                     }
                 }
                 break;
-            case Failed:
+                case failed:
                 return previousBuild.getPreviousFailedBuild();
-            case Successful:
+                case successful:
                 for (
                         previousBuild = previousBuild.getPreviousBuild();
                         previousBuild != null;
@@ -152,9 +152,9 @@ public class StatusRunSelector extends RunSelector {
                     }
                 }
                 break;
-            case Completed:
+                case completed:
                 return previousBuild.getPreviousCompletedBuild();
-            case Any:
+                case any:
                 return previousBuild.getPreviousBuild();
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/runselector/CopyArtifactTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/CopyArtifactTest.java
@@ -336,7 +336,7 @@ public class CopyArtifactTest {
                       p = createMatrixProject();
         p.setAxes(new AxisList(new Axis("FOO", "one", "two"))); // should match other job
         p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName() + "/FOO=$FOO", null,
-                new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
+                new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE), "", "", false, false, true));
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         MatrixBuild b = p.scheduleBuild2(0, new UserCause()).get();
         rule.assertBuildStatusSuccess(b);
@@ -479,7 +479,7 @@ public class CopyArtifactTest {
     @Test
     public void testDefaultExcludes() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE),
                 "", "", false, false));
         other.getBuildersList().add(new ArtifactBuilder());
         ArtifactArchiver aa = new ArtifactArchiver("**/*");
@@ -494,7 +494,7 @@ public class CopyArtifactTest {
     @Test
     public void testExcludes() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE),
                 "**", ".hg/**", "", false, false, true));
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**/*"));
@@ -508,7 +508,7 @@ public class CopyArtifactTest {
     @Test
     public void testDefaultExcludesWithFlatten() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE),
                 "", "", true, false));
         other.getBuildersList().add(new ArtifactBuilder());
         ArtifactArchiver aa = new ArtifactArchiver("**/*");
@@ -523,7 +523,7 @@ public class CopyArtifactTest {
     @Test
     public void testExcludesWithFlatten() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE),
                 "**", ".hg/**", "", true, false, true));
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**/*"));
@@ -1343,7 +1343,7 @@ public class CopyArtifactTest {
         FreeStyleProject p = folder2.createProject(FreeStyleProject.class, "bar");
 
         // "folder/foo" should be resolved as "/folder/foo" even from "/other/bar", for backward compatibility
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("folder/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("folder/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE), "", "", false, false, true));
 
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -1359,7 +1359,7 @@ public class CopyArtifactTest {
 
         MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "bar");
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE), "", "", false, false, true));
 
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -1375,7 +1375,7 @@ public class CopyArtifactTest {
 
         MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "bar");
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("../foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("../foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE), "", "", false, false, true));
 
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -1757,7 +1757,7 @@ public class CopyArtifactTest {
         p1.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
         rule.buildAndAssertSuccess(p1);
         FreeStyleProject p2 = rule.createFreeStyleProject("p2");
-        p2.getBuildersList().add(CopyArtifactUtil.createRunSelector("p1", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), null, "", false, false, true));
+        p2.getBuildersList().add(CopyArtifactUtil.createRunSelector("p1", null, new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE), null, "", false, false, true));
         FreeStyleBuild b = rule.buildAndAssertSuccess(p2);
         FilePath ws = b.getWorkspace();
         assertEquals("text", ws.child("plain").readToString());

--- a/src/test/java/org/jenkinsci/plugins/runselector/CopyArtifactTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/CopyArtifactTest.java
@@ -336,7 +336,7 @@ public class CopyArtifactTest {
                       p = createMatrixProject();
         p.setAxes(new AxisList(new Axis("FOO", "one", "two"))); // should match other job
         p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName() + "/FOO=$FOO", null,
-                new StatusRunSelector(StatusRunSelector.BuildStatus.Stable), "", "", false, false, true));
+                new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         MatrixBuild b = p.scheduleBuild2(0, new UserCause()).get();
         rule.assertBuildStatusSuccess(b);
@@ -479,7 +479,7 @@ public class CopyArtifactTest {
     @Test
     public void testDefaultExcludes() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.Stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
                 "", "", false, false));
         other.getBuildersList().add(new ArtifactBuilder());
         ArtifactArchiver aa = new ArtifactArchiver("**/*");
@@ -494,7 +494,7 @@ public class CopyArtifactTest {
     @Test
     public void testExcludes() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.Stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
                 "**", ".hg/**", "", false, false, true));
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**/*"));
@@ -508,7 +508,7 @@ public class CopyArtifactTest {
     @Test
     public void testDefaultExcludesWithFlatten() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.Stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
                 "", "", true, false));
         other.getBuildersList().add(new ArtifactBuilder());
         ArtifactArchiver aa = new ArtifactArchiver("**/*");
@@ -523,7 +523,7 @@ public class CopyArtifactTest {
     @Test
     public void testExcludesWithFlatten() throws Exception {
         FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.Stable),
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector(other.getName(), "", new StatusRunSelector(StatusRunSelector.BuildStatus.stable),
                 "**", ".hg/**", "", true, false, true));
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**/*"));
@@ -1343,7 +1343,7 @@ public class CopyArtifactTest {
         FreeStyleProject p = folder2.createProject(FreeStyleProject.class, "bar");
 
         // "folder/foo" should be resolved as "/folder/foo" even from "/other/bar", for backward compatibility
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("folder/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.Stable), "", "", false, false, true));
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("folder/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
 
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -1359,7 +1359,7 @@ public class CopyArtifactTest {
 
         MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "bar");
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.Stable), "", "", false, false, true));
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("/foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
 
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -1375,7 +1375,7 @@ public class CopyArtifactTest {
 
         MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "bar");
-        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("../foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.Stable), "", "", false, false, true));
+        p.getBuildersList().add(CopyArtifactUtil.createRunSelector("../foo", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "", "", false, false, true));
 
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -1757,7 +1757,7 @@ public class CopyArtifactTest {
         p1.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
         rule.buildAndAssertSuccess(p1);
         FreeStyleProject p2 = rule.createFreeStyleProject("p2");
-        p2.getBuildersList().add(CopyArtifactUtil.createRunSelector("p1", null, new StatusRunSelector(StatusRunSelector.BuildStatus.Stable), null, "", false, false, true));
+        p2.getBuildersList().add(CopyArtifactUtil.createRunSelector("p1", null, new StatusRunSelector(StatusRunSelector.BuildStatus.stable), null, "", false, false, true));
         FreeStyleBuild b = rule.buildAndAssertSuccess(p2);
         FilePath ws = b.getWorkspace();
         assertEquals("text", ws.child("plain").readToString());

--- a/src/test/java/org/jenkinsci/plugins/runselector/RunSelectorParameterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/RunSelectorParameterTest.java
@@ -62,7 +62,7 @@ public class RunSelectorParameterTest {
     public void testParameter() throws Exception {
         FreeStyleProject job = rule.createFreeStyleProject();
         job.addProperty(new ParametersDefinitionProperty(
-                new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.successful), "foo")));
+                new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.SUCCESSFUL), "foo")));
         CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
         job.getBuildersList().add(ceb);
 
@@ -110,7 +110,7 @@ public class RunSelectorParameterTest {
     
     @Test
     public void testConfiguration() throws Exception {
-        RunSelectorParameter expected = new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "foo");
+        RunSelectorParameter expected = new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE), "foo");
         FreeStyleProject job = rule.createFreeStyleProject();
         job.addProperty(new ParametersDefinitionProperty(expected));
         job.save();

--- a/src/test/java/org/jenkinsci/plugins/runselector/RunSelectorParameterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/RunSelectorParameterTest.java
@@ -62,7 +62,7 @@ public class RunSelectorParameterTest {
     public void testParameter() throws Exception {
         FreeStyleProject job = rule.createFreeStyleProject();
         job.addProperty(new ParametersDefinitionProperty(
-                new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.Successful), "foo")));
+                new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.successful), "foo")));
         CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
         job.getBuildersList().add(ceb);
 
@@ -110,7 +110,7 @@ public class RunSelectorParameterTest {
     
     @Test
     public void testConfiguration() throws Exception {
-        RunSelectorParameter expected = new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.Stable), "foo");
+        RunSelectorParameter expected = new RunSelectorParameter("SELECTOR", new StatusRunSelector(StatusRunSelector.BuildStatus.stable), "foo");
         FreeStyleProject job = rule.createFreeStyleProject();
         job.addProperty(new ParametersDefinitionProperty(expected));
         job.save();

--- a/src/test/java/org/jenkinsci/plugins/runselector/selectors/SpecificRunSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/selectors/SpecificRunSelectorTest.java
@@ -24,6 +24,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+/**
+ * Tests for {@link SpecificRunSelector}.
+ *
+ * @author Alexandru Somai
+ */
 public class SpecificRunSelectorTest {
 
     @ClassRule

--- a/src/test/java/org/jenkinsci/plugins/runselector/selectors/StatusRunSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/selectors/StatusRunSelectorTest.java
@@ -1,0 +1,108 @@
+package org.jenkinsci.plugins.runselector.selectors;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.apache.commons.lang.RandomStringUtils;
+import org.jenkinsci.plugins.runselector.RunSelector;
+import org.jenkinsci.plugins.runselector.context.RunSelectorContext;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link StatusRunSelector}.
+ *
+ * @author Alexandru Somai
+ */
+public class StatusRunSelectorTest {
+
+    @ClassRule
+    public static final JenkinsRule j = new JenkinsRule();
+
+    private static WorkflowJob jobToSelect;
+    private static WorkflowRun successRun;
+    private static WorkflowRun unstableRun;
+    private static WorkflowRun failureRun;
+    private static WorkflowRun abortedRun;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        jobToSelect = j.jenkins.createProject(WorkflowJob.class, RandomStringUtils.randomAlphanumeric(7));
+
+        jobToSelect.setDefinition(new CpsFlowDefinition("currentBuild.result = 'SUCCESS'"));
+        successRun = jobToSelect.scheduleBuild2(0).get();
+
+        jobToSelect.setDefinition(new CpsFlowDefinition("currentBuild.result = 'UNSTABLE'"));
+        unstableRun = jobToSelect.scheduleBuild2(0).get();
+
+        jobToSelect.setDefinition(new CpsFlowDefinition("currentBuild.result = 'FAILURE'"));
+        failureRun = jobToSelect.scheduleBuild2(0).get();
+
+        jobToSelect.setDefinition(new CpsFlowDefinition("currentBuild.result = 'ABORTED'"));
+        abortedRun = jobToSelect.scheduleBuild2(0).get();
+    }
+
+    @Test
+    public void testLastStableBuild() throws Exception {
+        RunSelector selector = new StatusRunSelector(StatusRunSelector.BuildStatus.STABLE);
+        verifySelectedRun(selector, successRun);
+    }
+
+    @Test
+    public void testLastSuccessfulBuild() throws Exception {
+        RunSelector selector = new StatusRunSelector(StatusRunSelector.BuildStatus.SUCCESSFUL);
+        verifySelectedRun(selector, unstableRun);
+    }
+
+    @Test
+    public void testLastUnstableBuild() throws Exception {
+        RunSelector selector = new StatusRunSelector(StatusRunSelector.BuildStatus.UNSTABLE);
+        verifySelectedRun(selector, unstableRun);
+    }
+
+    @Test
+    public void testLastFailedBuild() throws Exception {
+        RunSelector selector = new StatusRunSelector(StatusRunSelector.BuildStatus.FAILED);
+        verifySelectedRun(selector, failureRun);
+    }
+
+    @Test
+    public void testLastCompletedBuild() throws Exception {
+        RunSelector selector = new StatusRunSelector(StatusRunSelector.BuildStatus.COMPLETED);
+        verifySelectedRun(selector, abortedRun);
+    }
+
+    @Test
+    public void testLastAnyBuild() throws Exception {
+        RunSelector selector = new StatusRunSelector(StatusRunSelector.BuildStatus.ANY);
+        verifySelectedRun(selector, abortedRun);
+    }
+
+    @Test
+    public void testWorkflow() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, RandomStringUtils.randomAlphanumeric(7));
+        job.setDefinition(new CpsFlowDefinition(String.format("" +
+                        "def runWrapper = selectRun job: '%s', " +
+                        " selector: [$class: 'StatusRunSelector', buildStatus: 'STABLE'] \n" +
+                        "assert runWrapper.id == '%s'",
+                jobToSelect.getFullName(), successRun.getId())));
+
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+    }
+
+    private static void verifySelectedRun(RunSelector selector, Run expectedRun) throws Exception {
+        FreeStyleProject selecter = j.createFreeStyleProject();
+
+        Run run = j.assertBuildStatusSuccess(selecter.scheduleBuild2(0));
+        Run selectedRun = selector.select(jobToSelect, new RunSelectorContext(j.jenkins, run, TaskListener.NULL));
+        assertThat(selectedRun, is(expectedRun));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/runselector/steps/SelectRunStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/steps/SelectRunStepTest.java
@@ -80,7 +80,7 @@ public class SelectRunStepTest {
                 "echo 'Selected run: ' + runWrapper.displayName", projectName));
 
         j.assertBuildStatusSuccess(run);
-        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (stable)", run);
+        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (STABLE)", run);
         j.assertLogContains("Run Filter was not provided", run);
         j.assertLogContains("Selected run: #1", run);
     }
@@ -94,9 +94,9 @@ public class SelectRunStepTest {
         WorkflowRun run = createWorkflowJobAndRun(format("def runWrapper = selectRun '%s' ", projectName));
 
         j.assertBuildStatus(Result.FAILURE, run);
-        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (stable)", run);
+        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (STABLE)", run);
         j.assertLogContains("Run Filter was not provided", run);
-        j.assertLogContains(format("ERROR: Unable to find Run for: %s, with selector: Latest specific status build (stable) and filter: No Filter", projectName), run);
+        j.assertLogContains(format("ERROR: Unable to find Run for: %s, with selector: Latest specific status build (STABLE) and filter: No Filter", projectName), run);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/runselector/steps/SelectRunStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/runselector/steps/SelectRunStepTest.java
@@ -80,7 +80,7 @@ public class SelectRunStepTest {
                 "echo 'Selected run: ' + runWrapper.displayName", projectName));
 
         j.assertBuildStatusSuccess(run);
-        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (Stable)", run);
+        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (stable)", run);
         j.assertLogContains("Run Filter was not provided", run);
         j.assertLogContains("Selected run: #1", run);
     }
@@ -94,9 +94,9 @@ public class SelectRunStepTest {
         WorkflowRun run = createWorkflowJobAndRun(format("def runWrapper = selectRun '%s' ", projectName));
 
         j.assertBuildStatus(Result.FAILURE, run);
-        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (Stable)", run);
+        j.assertLogContains("Run Selector was not provided, using the default one: Latest specific status build (stable)", run);
         j.assertLogContains("Run Filter was not provided", run);
-        j.assertLogContains(format("ERROR: Unable to find Run for: %s, with selector: Latest specific status build (Stable) and filter: No Filter", projectName), run);
+        j.assertLogContains(format("ERROR: Unable to find Run for: %s, with selector: Latest specific status build (stable) and filter: No Filter", projectName), run);
     }
 
     @Test


### PR DESCRIPTION
One of the changes that @jglick suggested on this thread https://groups.google.com/forum/#!topic/jenkinsci-dev/IZ2EZR6tjXo was to use de-camel cased names: `successful` instead of `Successful`. 
So that the Pipeline syntax would be:

``` groovy
def runWrapper = runSelector job: 'upstream-project-name', 
  selector: [$class: 'StatusRunSelector', buildStatus: 'successful'] 
```

This means that I have to change the enum names, so the code base looks like in this PR.
Personally I don't like that much having enums with de-camel cased names.

What if I change the syntax to upper case? To have `SUCCESSFUL` (personally I'd prefer this one).
e.g. 

``` groovy
def runWrapper = runSelector job: 'upstream-project-name', 
  selector: [$class: 'StatusRunSelector', buildStatus: 'SUCCESSFUL']
```

Opinions @jglick @ikedam @oleg-nenashev @martinda?
