### PR TITLE
Use GitHub as a plugin documentation source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>hpi</packaging>
     <name>Run Selector Plugin</name>
     <version>1.1.1-SNAPSHOT</version>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Run+Selector+Plugin</url>
+    <url>https://github.com/jenkinsci/run-selector-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/